### PR TITLE
Users to choose the metrics of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ fo create PDF files which are used by ImageMagick to generate the GIF.
 If successfuly ran, the `run_simple_example.py` script will output<sup>*</sup>:
 
 <pre>
-Scenario : makespan : utilization : average_job_utilization : average_job_response_time : average_job_stretch : average_job_wait_time : failures
-test_batch : 526.00 : 0.54 : 0.70 : 291.55 : 8.76 : 209.50 : 1
-test_online : 421.00 : 0.67 : 0.70 : 285.91 : 8.96 : 204.33 : 1
+Scenario name : job failures : job response time : job stretch : job utilization : job wait time : system makespan : system utilization :
+test_batch : 1.00 : 361.64 : 5.78 : 0.73 : 259.08 : 606.00 : 0.67 :
+test_online : 1.00 : 374.91 : 6.86 : 0.73 : 271.25 : 553.00 : 0.74 :
 GIFs generated in ./draw/test_{batch, online}.gif
 </pre>
 

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -185,8 +185,9 @@ class Simulator():
             self.__execution_log = runtime.get_stats()
 
             if self.__check_correctness:
-                check += self.test_correctness()
-                if check > 0:
+                check_loop = self.test_correctness()
+                check += check_loop
+                if check_loop > 0:
                     self.logger.debug("FAIL correctness test (loop %d)" % (i))
                     continue
 
@@ -207,7 +208,7 @@ class Simulator():
             self.horizontal_ax = self.__viz_handler.generate_scenario_gif(
                 self.__scenario_name)
             self.logger.info(r"GIF generated draw/%s" % (self.__scenario_name))
-        return check
+        return self.stats.get_metric_values()
 
 
 class Application(object):

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -18,7 +18,7 @@ class Simulator():
     ''' Main class of the simulation '''
 
     def __init__(self, loops=1, generate_gif=False, check_correctness=False,
-                 output_file_handler=None):
+                 output_file_handler=None, metrics=["all"]):
         ''' Constructor defining the main properties of a simulation '''
 
         assert (loops > 0), "Number of loops has to be a positive integer"
@@ -29,6 +29,7 @@ class Simulator():
         self.__execution_log = {}
         self.job_list = []
         self.logger = logging.getLogger(__name__)
+        self.__metrics = metrics
 
         self.__fp = output_file_handler
 
@@ -191,6 +192,7 @@ class Simulator():
                     continue
 
             self.stats.set_execution_output(self.__execution_log)
+            self.stats.set_metrics(self.__metrics)
             self.logger.info(self.stats)
             if self.__fp is not None:
                 self.stats.print_to_file(self.__fp, self.__scenario_name)

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -18,7 +18,7 @@ class Simulator():
     ''' Main class of the simulation '''
 
     def __init__(self, loops=1, generate_gif=False, check_correctness=False,
-                 output_file_handler=None, metrics=["all"]):
+                 output_file_handler=None):
         ''' Constructor defining the main properties of a simulation '''
 
         assert (loops > 0), "Number of loops has to be a positive integer"
@@ -29,7 +29,6 @@ class Simulator():
         self.__execution_log = {}
         self.job_list = []
         self.logger = logging.getLogger(__name__)
-        self.__metrics = metrics
 
         self.__fp = output_file_handler
 
@@ -174,7 +173,7 @@ class Simulator():
         check_fail += self.__sainity_check_schedule(self.__execution_log)
         return check_fail
 
-    def run(self):
+    def run(self, metrics=["all"]):
         ''' Main method of the simulator that triggers the start of
         a given simulation scenario '''
 
@@ -192,7 +191,7 @@ class Simulator():
                     continue
 
             self.stats.set_execution_output(self.__execution_log)
-            self.stats.set_metrics(self.__metrics)
+            self.stats.set_metrics(metrics)
             self.logger.info(self.stats)
             if self.__fp is not None:
                 self.stats.print_to_file(self.__fp, self.__scenario_name)

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -195,7 +195,7 @@ class Simulator():
             self.stats.set_metrics(metrics)
             self.logger.info(self.stats)
             if self.__fp is not None:
-                self.stats.print_to_file(self.__fp, self.__scenario_name)
+                self.stats.print_to_file(self.__fp, self.__scenario_name, i)
 
         if check == 0:
             self.logger.info("PASS correctness test")

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -617,6 +617,14 @@ class StatsEngine():
                         job.walltime)
         return stretch / max(1, len(self.__execution_log))
 
+    def get_metric_values(self):
+        if len(self.__execution_log) == 0:
+            return {}
+        ret = {}
+        for metric in self.__metrics:
+            ret[metric] = self.__metric_mapping[metric]()
+        return ret
+
     def print_to_file(self, file_handler, scenario):
         ''' Print all metrics to a file handler '''
 

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -527,6 +527,10 @@ class StatsEngine():
         self.__makespan = max([max([i[1] for i in self.__execution_log[job]])
                                for job in self.__execution_log])
     
+    def __add_metric_list(self, metric_name):
+        self.__metrics |= set([metric for metric in self.__metric_mapping
+                              if metric_name in metric])
+
     def set_metrics(self, metric_list):
         ''' Add the metrics of interest for the current simulation '''
 
@@ -535,6 +539,9 @@ class StatsEngine():
                 return self.__metrics
         self.__metrics = set()
         for metric in metric_list:
+            if "all" in metric:
+                self.__add_metric_list(metric[4:])
+                continue
             if metric not in self.__metric_mapping:
                 continue
             self.__metrics.add(metric)
@@ -565,7 +572,7 @@ class StatsEngine():
         total_wait = 0
         total_runs = 0
         for job in self.__execution_log:
-            submission = 0
+            submission = job.submission_time
             apl_wait = 0
             for instance in self.__execution_log[job]:
                 apl_wait += instance[0] - submission

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -539,7 +539,7 @@ class StatsEngine():
                 return self.__metrics
         self.__metrics = set()
         for metric in metric_list:
-            if "all" in metric:
+            if "all" in metric[:4]:
                 self.__add_metric_list(metric[4:])
                 continue
             if metric not in self.__metric_mapping:

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -625,11 +625,19 @@ class StatsEngine():
             ret[metric] = self.__metric_mapping[metric]()
         return ret
 
-    def print_to_file(self, file_handler, scenario):
+    def print_to_file(self, file_handler, scenario, loop_id):
         ''' Print all metrics to a file handler '''
 
         if len(self.__execution_log) == 0:
             return -1
+        # if printing the first loop, print the header
+        if loop_id == 0:
+            file_handler.write("Scenario name : ")
+            for metric in self.__metrics:
+                file_handler.write("%s :" %(metric))
+            file_handler.write("\n")
+
+        # print metric values
         file_handler.write("%s : " %(scenario))
         for metric in self.__metrics:
             file_handler.write("%.2f : " %

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -493,6 +493,16 @@ class StatsEngine():
         self.__execution_log = {}
         self.__makespan = -1
         self.__total_nodes = total_nodes
+        
+        self.__metric_mapping = {
+            "system makespan" : self.total_makespan,
+            "system utilization" : self.system_utilization,
+            "job utilization" : self.average_job_utilization,
+            "job response time" : self.average_job_response_time,
+            "job stretch" : self.average_job_stretch,
+            "job wait time" : self.average_job_wait_time,
+            "job failures" : self.total_failures}
+        self.__metrics = set([i for i in self.__metric_mapping])
 
     def __str__(self):
         if len(self.__execution_log) == 0:
@@ -516,7 +526,20 @@ class StatsEngine():
         self.__execution_log = execution_log
         self.__makespan = max([max([i[1] for i in self.__execution_log[job]])
                                for job in self.__execution_log])
+    
+    def set_metrics(self, metric_list):
+        ''' Add the metrics of interest for the current simulation '''
 
+        for metric in metric_list:
+            if metric == "all":
+                return self.__metrics
+        self.__metrics = set()
+        for metric in metric_list:
+            if metric not in self.__metric_mapping:
+                continue
+            self.__metrics.add(metric)
+        return self.__metrics
+    
     def total_makespan(self):
         ''' Time from simulation beginning last job end '''
         return self.__makespan
@@ -592,12 +615,8 @@ class StatsEngine():
 
         if len(self.__execution_log) == 0:
             return -1
-        file_handler.write(
-            "%s : %.2f : %.2f : %.2f : %.2f : %.2f : %.2f : %d\n" %
-            (scenario, self.total_makespan(),
-             self.system_utilization(),
-             self.average_job_utilization(),
-             self.average_job_response_time(),
-             self.average_job_stretch(),
-             self.average_job_wait_time(),
-             self.total_failures()))
+        file_handler.write("%s : " %(scenario))
+        for metric in self.__metrics:
+            file_handler.write("%.2f : " %
+            (self.__metric_mapping[metric]()))
+        file_handler.write("\n")

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -502,7 +502,8 @@ class StatsEngine():
             "job stretch" : self.average_job_stretch,
             "job wait time" : self.average_job_wait_time,
             "job failures" : self.total_failures}
-        self.__metrics = set([i for i in self.__metric_mapping])
+        self.__metrics = [i for i in self.__metric_mapping]
+        self.__metrics.sort()
 
     def __str__(self):
         if len(self.__execution_log) == 0:
@@ -545,6 +546,10 @@ class StatsEngine():
             if metric not in self.__metric_mapping:
                 continue
             self.__metrics.add(metric)
+
+        # set order is not deterministic when parsed
+        self.__metrics = list(self.__metrics)
+        self.__metrics.sort()
         return self.__metrics
     
     def total_makespan(self):
@@ -634,7 +639,7 @@ class StatsEngine():
         if loop_id == 0:
             file_handler.write("Scenario name : ")
             for metric in self.__metrics:
-                file_handler.write("%s :" %(metric))
+                file_handler.write("%s : " %(metric))
             file_handler.write("\n")
 
         # print metric values

--- a/run_simple_example.py
+++ b/run_simple_example.py
@@ -46,8 +46,4 @@ if __name__ == '__main__':
     job_list.add(ScheduleFlow.Application(np.random.randint(9, 11), 0,
                                           100, [90, 135]))
 
-    print("Scenario : makespan : utilization : average_job_utilization : "
-          "average_job_response_time : average_job_stretch : "
-          "average_job_wait_time : failures")
-
     run_scenario(num_processing_units, job_list)

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -741,8 +741,8 @@ class TestSimulator(unittest.TestCase):
             "test",
             ScheduleFlow.BatchScheduler(ScheduleFlow.System(10)),
             job_list=job_list)
-        ret = sim.run()
-        self.assertEqual(ret, 0)
+        sim.run()
+        self.assertEqual(sim.test_correctness(), 0)
 
     def test_simulation_correctness(self):
         sim = ScheduleFlow.Simulator(check_correctness=True)


### PR DESCRIPTION
For each simulation the metrics used are chosen by the user

Default all
"system makespan" : self.total_makespan,
"system utilization" : self.system_utilization,
"job utilization" : self.average_job_utilization,
"job response time" : self.average_job_response_time,
"job stretch" : self.average_job_stretch,
"job wait time" : self.average_job_wait_time,
"job failures" : self.total_failures}

When all is used string search will choose all appropriate metrics:
for example "all system" will choose system makespan and system utilization metrics

Simple example, test units, README and API need to be updated
