### PR TITLE
Allowing application checkpoint at the end of a reservation

### DIFF
--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -326,16 +326,15 @@ class Application(object):
     def __lt__(self, job):
         return self.job_id < job.job_id
 
-    def set_checkpointing(self, checkpoint_size,
-                          resubmission_checkpointing=False):
+    def set_checkpointing(self, checkpoint_size_list):
         ''' Method for setting the checkpoint/restart characteristics:
             (1) what is the checkpoint size for each submission;
             (2) is each submission checkpointed at the end;
             (3) resubmit_factor resubmissions are checkpointed '''
         # 0 or negative values indicate no checkpoint
-        self.current_checkpoint = checkpoint_size[0]
-        if len(checkpoint_size)>1:
-            self.checkpoint_sequence = checkpoint_size[1:]
+        self.current_checkpoint = checkpoint_size_list[0]
+        if len(checkpoint_size_list)>1:
+            self.checkpoint_sequence = checkpoint_size_list[1:]
         # once the checkpoint_sequnce becomes empty, resubmissions will be
         # always or never checkpointed based on self.checkpointing
 

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -140,7 +140,7 @@ class Simulator():
             # in case the last submission was checkpointed, the expected
             # time must also include the checkpoint read time
             expected_time += job.get_checkpoint_read_time(
-                step = len(execution_list)-1)
+                step=len(execution_list) - 1)
         else:
             expected_time = requested_time
         if not np.isclose(end-start, expected_time,
@@ -296,7 +296,7 @@ class Application(object):
         self.request_sequence = requested_walltimes
         # keep track of the number of submission
         self.submission_count = 0
-        
+
         self.resubmit = True
         if resubmit_factor == -1:
             if len(self.request_sequence) == 0:
@@ -342,12 +342,12 @@ class Application(object):
             Entries with 0 or negative values indicate no checkpoint
             for the respective submission. Submissions after the entries
             in the list will use the last value '''
-        
+
         assert(len(checkpoint_size_list) > 0),\
             "Cannot set an empty checkpoint list"
         self.checkpointing = True
         # sequences containing negative values on the last position indicate
-        # not to checkpoint for future resubmissions 
+        # not to checkpoint for future resubmissions
         self.current_checkpoint = checkpoint_size_list[0]
         self.checkpoint_sequence = checkpoint_size_list
 
@@ -397,7 +397,7 @@ class Application(object):
             sel_system = self.system
         assert(sel_system is not None),\
             "Job must be running on a system to compute the request time"
-        
+
         write_checkpoint = sel_system.get_write_time(
             self.current_checkpoint)
         read_checkpoint = self.get_checkpoint_read_time(system=sel_system)
@@ -431,7 +431,7 @@ class Application(object):
 
         if not self.checkpointing:
             return self.get_request_time(step)
-        
+
         assert(self.system is not None),\
             "Job must be running on a system to compute the request time"
         request_walltime = self.get_request_time(step)
@@ -493,7 +493,7 @@ class Application(object):
             self.walltime = restore[1]
 
         # restore the sequence of request times
-        self.request_walltime =  self.get_request_time(0)
+        self.request_walltime = self.get_request_time(0)
 
         # restore first checkpoint
         self.current_checkpoint = self.get_checkpoint_size(0)
@@ -507,7 +507,7 @@ class Application(object):
 
 
 class System(object):
-    ''' System class containing available resources 
+    ''' System class containing available resources
         (default I/O bandwidth per core of 1 MB/s for both read/write) '''
 
     def __init__(self, total_nodes, io_write_bw=1, io_read_bw=1):
@@ -632,7 +632,7 @@ class Scheduler(object):
 
         start_time = max(job.submission_time, current_time)
         request_walltime = job.get_current_total_request_time(
-            system = self.system)
+            system=self.system)
         gap_list = self.gaps_in_schedule.get_gaps(start_time,
                                                   request_walltime,
                                                   job.nodes)

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -399,15 +399,18 @@ class Application(object):
 
 
 class System(object):
-    ''' System class containing available resources (for now just nodes) '''
+    ''' System class containing available resources 
+        (default I/O bandwidth per core of 1 MB/s for both read/write) '''
 
-    def __init__(self, total_nodes):
+    def __init__(self, total_nodes, io_write_bw=1, io_read_bw=1):
         assert (total_nodes > 0),\
             r'Number of nodes of a system must be > 0: received %d' % (
             total_nodes)
 
         self.__total_nodes = total_nodes
         self.__free_nodes = total_nodes
+        self.__IO_write_bw = io_write_bw
+        self.__IO_read_bw = io_read_bw
 
     def __str__(self):
         return 'System: %d total nodes (%d currently free)' % (
@@ -422,6 +425,12 @@ class System(object):
 
     def get_total_nodes(self):
         return self.__total_nodes
+
+    def get_write_time(self, dump_size):
+        return dump_size * self.__IO_write_bw
+
+    def get_read_time(self, dump_size):
+        return dump_size * self.__IO_read_bw
 
     def start_job(self, nodes, jobid):
         ''' Method for aquiring resources in the system '''

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -413,18 +413,22 @@ class Application(object):
     def restore_default_values(self):
         ''' Method for restoring the initial submission values '''
         restore = next((i for i in self.__execution_log if
-                        i[0] == JobChangeType.RequestSequenceOverwrite), None)
-        if restore is not None:
-            self.request_sequence = restore[1][:]
-        restore = next((i for i in self.__execution_log if
                         i[0] == JobChangeType.SubmissionChange), None)
         if restore is not None:
             self.submission_time = restore[1]
+
+        # restore the sequence of request times
+        restore = next((i for i in self.__execution_log if
+                        i[0] == JobChangeType.RequestSequenceOverwrite), None)
+        if restore is not None:
+            self.request_sequence = restore[1][:]
+        
         restore = next((i for i in self.__execution_log if
                         i[0] == JobChangeType.RequestChange), None)
         if restore is not None:
             self.request_walltime = restore[1]
 
+        # restore the sequence of checkpointing size
         restore = [i[1] for i in self.__execution_log if
                    i[0] == JobChangeType.CheckpointSizeChange]
         if len(restore) > 0:
@@ -441,6 +445,10 @@ class Application(object):
 
         # clear the execution log
         self.__execution_log = []
+        if len(self.request_sequence) > 0:
+            self.__execution_log.append(
+                    (JobChangeType.RequestSequenceOverwrite,
+                     self.request_sequence[:]))
 
 
 class System(object):

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -385,7 +385,7 @@ class Application(object):
 
     def update_submission(self, submission_time):
         ''' Method to update submission information including
-        the submission time and the walltime request '''
+        the submission time, the walltime request and the checkpoint size '''
 
         assert (submission_time >= 0),\
             r'Negative submission time received: %d' % (
@@ -404,6 +404,12 @@ class Application(object):
                                         self.request_walltime)
         if self.resubmit_factor == 1 and len(self.request_sequence) == 0:
             self.resubmit = False
+
+        if len(self.checkpoint_sequence) > 0:
+            self.__execution_log.append((JobChangeType.CheckpointSizeChange,
+                                         self.current_checkpoint))
+            self.current_checkpoint = self.checkpoint_sequence[0]
+            del self.checkpoint_sequence[0]
 
     def restore_default_values(self):
         ''' Method for restoring the initial submission values '''

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -308,6 +308,8 @@ class Application(object):
 
         # By default checkpointing is False
         self.checkpoiting = False
+        self.current_checkpoint = -1
+        self.checkpoint_sequence = []
 
     def __str__(self):
         return 'Job %d: %d nodes; %3.1f submission time; %3.1f total ' \
@@ -325,7 +327,7 @@ class Application(object):
     def __lt__(self, job):
         return self.job_id < job.job_id
 
-    def set_checkpointing(self, checkpoit_size,
+    def set_checkpointing(self, checkpoint_size,
                           resubmission_checkpointing=False):
         ''' Method for setting the checkpoint/restart characteristics:
             (1) what is the checkpoint size for each submission;

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -480,10 +480,14 @@ class System(object):
         return self.__total_nodes
 
     def get_write_time(self, dump_size):
-        return dump_size * self.__IO_write_bw
+        if dump_size <= 0:
+            return 0
+        return int(dump_size * self.__IO_write_bw)
 
     def get_read_time(self, dump_size):
-        return dump_size * self.__IO_read_bw
+        if dump_size <= 0:
+            return 0
+        return int(dump_size * self.__IO_read_bw)
 
     def start_job(self, nodes, jobid):
         ''' Method for aquiring resources in the system '''

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -306,6 +306,9 @@ class Application(object):
                     (JobChangeType.RequestSequenceOverwrite,
                      self.request_sequence[:]))
 
+        # By default checkpointing is False
+        self.checkpoiting = False
+
     def __str__(self):
         return 'Job %d: %d nodes; %3.1f submission time; %3.1f total ' \
                'execution time (%3.1f requested)' % (
@@ -321,6 +324,22 @@ class Application(object):
 
     def __lt__(self, job):
         return self.job_id < job.job_id
+
+    def set_checkpointing(self, checkpoit_size,
+                          resubmission_checkpointing=False):
+        ''' Method for setting the checkpoint/restart characteristics:
+            (1) what is the checkpoint size for each submission;
+            (2) is each submission checkpointed at the end;
+            (3) resubmit_factor resubmissions are checkpointed (if yes,
+            using what value for the checkpoint size '''
+        if resubmission_checkpointing:
+            self.checkpoiting = True
+        # negative values indicate no checkpoint
+        self.current_checkpoint = checkpoint_size[0]
+        if len(checkpoint_size)>1:
+            self.checkpoint_sequence = checkpoint_size[1:]
+        # once the checkpoint_sequnce becomes empty, resubmissions will be
+        # always or never checkpointed based on self.checkpointing
 
     def get_request_time(self, step):
         ''' Method for descovering the request time that the job will use

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -301,11 +301,11 @@ class Application(object):
         if resubmit_factor == -1:
             if len(self.request_sequence) == 0:
                 self.resubmit = False
-            self.resubmit_factor = 1
+            self.resubmit_factor = 0
         else:
-            assert (resubmit_factor > 1),\
+            assert (resubmit_factor > 0),\
                 'Increase factor for an execution request time must be ' \
-                'over 1: received %d' % (resubmit_factor)
+                'over 0: received %d' % (resubmit_factor)
             self.resubmit_factor = resubmit_factor
 
         # Entries in the execution log: (JobChangeType, old_value)
@@ -416,6 +416,10 @@ class Application(object):
         if step < len(self.request_sequence):
             return self.request_sequence[step]
 
+        # if the resubmit factor is not set, there are no more submissions
+        if self.resubmit_factor == 0:
+            return -1
+
         seq_len = len(self.request_sequence)
         return self.request_sequence[-1] * pow(
             self.resubmit_factor, step - seq_len + 1)
@@ -469,7 +473,7 @@ class Application(object):
         assert (old_request_gap > (self.walltime - self.request_walltime)),\
             "The new request walltime has to be greater than the last one"
 
-        if self.resubmit_factor == 1:
+        if self.resubmit_factor == 0:
             if self.submission_count >= len(self.request_sequence) - 1:
                 self.resubmit = False
         # update the checkpoiting
@@ -496,7 +500,7 @@ class Application(object):
         self.current_checkpoint = self.get_checkpoint_size(0)
 
         self.resubmit = True
-        if self.resubmit_factor == 1 and len(self.request_sequence) == 0:
+        if self.resubmit_factor == 0 and len(self.request_sequence) == 0:
             self.resubmit = False
 
         # clear the execution log

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -312,7 +312,7 @@ class Application(object):
         self.__execution_log = []
 
         # By default checkpointing is False
-        self.checkpoiting = False
+        self.checkpointing = False
         self.current_checkpoint = 0
         self.checkpoint_sequence = []
         # by default the job is not running on any system
@@ -345,10 +345,10 @@ class Application(object):
         
         assert(len(checkpoint_size_list) > 0),\
             "Cannot set an empty checkpoint list"
-        self.checkpoiting = True
+        self.checkpointing = True
         # 0 or negative values indicate no checkpoint
         self.current_checkpoint = checkpoint_size_list[0]
-        self.checkpoint_sequence = checkpoint_size_list[:]
+        self.checkpoint_sequence = checkpoint_size_list
         # once the checkpoint_sequnce becomes empty, resubmissions will be
         # always or never checkpointed based on self.checkpointing
 
@@ -362,9 +362,9 @@ class Application(object):
             return self.checkpoint_sequence[step]
         return self.checkpoint_sequence[-1]
 
-    def get_checkpoint_read_time(self, system=None):
+    def get_checkpoint_read_time(self, system=None, step=None):
         ''' Method that returns the time to read the previous checkpoint '''
-        if not self.checkpoiting:
+        if not self.checkpointing:
             return 0
 
         sel_system = system
@@ -390,7 +390,7 @@ class Application(object):
         (if it's required) and the time to read the latest checkpoint
         (if necessary) '''
 
-        if not self.checkpoiting:
+        if not self.checkpointing:
             return self.request_walltime
 
         sel_system = system
@@ -430,7 +430,7 @@ class Application(object):
         to checkpoint at the end (if it's required) and the time to read
         the latest checkpoint (if necessary) '''
 
-        if not self.checkpoiting:
+        if not self.checkpointing:
             return self.get_request_time(step)
         
         assert(self.system is not None),\
@@ -476,8 +476,8 @@ class Application(object):
         if self.resubmit_factor == 0:
             if self.submission_count >= len(self.request_sequence) - 1:
                 self.resubmit = False
-        # update the checkpoiting
-        if self.checkpoiting:
+        # update the checkpointing
+        if self.checkpointing:
             self.current_checkpoint = self.get_checkpoint_size(
                 self.submission_count)
 

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -428,9 +428,12 @@ class Application(object):
         restore = [i[1] for i in self.__execution_log if
                    i[0] == JobChangeType.CheckpointSizeChange]
         if len(restore) > 0:
-            self.current_chekpoint = restore[0]
+            restore_check = []
             if len(restore) > 1:
-                self.checkpoint_sequence = restore[1:]
+                restore_check = restore[1:]
+            restore_check += [self.current_checkpoint]
+            self.current_checkpoint = restore[0]
+            self.checkpoint_sequence = restore_check + self.checkpoint_sequence
 
         self.resubmit = True
         if self.resubmit_factor == 1 and len(self.request_sequence) == 0:

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -426,6 +426,13 @@ class Application(object):
         if restore is not None:
             self.request_walltime = restore[1]
 
+        restore = [i[1] for i in self.__execution_log if
+                   i[0] == JobChangeType.CheckpointSizeChange]
+        if len(restore) > 0:
+            self.current_chekpoint = restore[0]
+            if len(restore) > 1:
+                self.checkpoint_sequence = restore[1:]
+
         self.resubmit = True
         if self.resubmit_factor == 1 and len(self.request_sequence) == 0:
             self.resubmit = False

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -563,7 +563,7 @@ class Scheduler(object):
         to run from the waiting queue at the current schedule cycle '''
         return []
 
-    def fit_job_in_schedule(self, job, reserved_jobs, current_time=0):
+    def fit_job_in_schedule(self, job, current_time=0):
         ''' Base method that fits a new job into an existing schedule.
         The `reserved_jobs` consists of a list of [start time, job].
         The base method assumes a reservation based scheduler: the end of
@@ -573,15 +573,12 @@ class Scheduler(object):
         The method returns -1 if the job does not fit into the schedule
         and timestamp otherwise '''
 
-        if len(reserved_jobs) == 0:
-            return -1
         start_time = max(job.submission_time, current_time)
         gap_list = self.gaps_in_schedule.get_gaps(start_time,
                                                   job.request_walltime,
                                                   job.nodes)
         self.logger.debug(
-            r'[Scheduler] Reservation list: %s; Gaps: %s' % (
-                reserved_jobs, gap_list))
+            r'[Scheduler] Schedule job: %s; Gaps: %s' % (job, gap_list))
         if len(gap_list) == 0:
             return -1
 
@@ -764,7 +761,7 @@ class BatchScheduler(Scheduler):
         selected_jobs = []
         for job in batch_jobs:
             tm = super(BatchScheduler, self).fit_job_in_schedule(
-                job, reserved_jobs, current_time=current_time)
+                job, current_time=current_time)
             if tm != -1:
                 selected_jobs.append((tm, job))
                 reserved_jobs[job] = tm
@@ -858,14 +855,11 @@ class OnlineScheduler(Scheduler):
             free_nodes -= job.nodes
         return selected_jobs
 
-    def fit_job_in_schedule(self, job, reserved_jobs, current_time=0):
+    def fit_job_in_schedule(self, job, current_time=0):
         ''' Method that overwrites the base class that implements a
         reservation based algorithm. For the base method all jobs
         need to be fitted in the reservation window and cannot exceed
         the end. Online methods do not have this limitation '''
-
-        if len(reserved_jobs) == 0:
-            return -1
 
         gap_list = self.gaps_in_schedule.get_gaps(job.submission_time,
                                                   0, job.nodes)

--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -436,6 +436,9 @@ class Application(object):
         if self.resubmit_factor == 1 and len(self.request_sequence) == 0:
             self.resubmit = False
 
+        # clear the execution log
+        self.__execution_log = []
+
 
 class System(object):
     ''' System class containing available resources 

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -567,7 +567,7 @@ class Runtime(object):
 
         tm = -1
         if can_start:
-            tm = self.scheduler.fit_job_in_schedule(job, self.__reserved_jobs)
+            tm = self.scheduler.fit_job_in_schedule(job)
         # check if the job can fit in the current reservations
         # if yes and if it is allowed, send it for execution
         if tm != -1:

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -219,7 +219,7 @@ class ScheduleGaps(object):
     def trim(self, current_time):
         ''' Delete all gaps that end before the current timestamp '''
         job_list = [job for job in self.__reserved_jobs if
-                    (self.__reserved_jobs[job] +\
+                    (self.__reserved_jobs[job] +
                      job.get_current_total_request_time()) <
                     current_time]
         for job in job_list:
@@ -340,7 +340,7 @@ class ScheduleGaps(object):
                     gaps_list[i][1] = end
 
         remove_list = sorted(list(remove_list), reverse=True)
-        if len(remove_list)==0:
+        if len(remove_list) == 0:
             return 0
         for idx in remove_list:
             del gaps_list[idx]
@@ -349,17 +349,17 @@ class ScheduleGaps(object):
     def __fill_gap_to_neighbors(self, new_job):
         ''' Add neighbor space on the left and right of the new job '''
 
-        new_gaps = [] 
+        new_gaps = []
         start = self.__reserved_jobs[new_job]
-        left_gaps = [self.__reserved_jobs[job] +\
+        left_gaps = [self.__reserved_jobs[job] +
                      job.get_current_total_request_time()
                      for job in self.__reserved_jobs if
-                     self.__reserved_jobs[job] +\
+                     self.__reserved_jobs[job] +
                      job.get_current_total_request_time() <= start]
         if len(left_gaps) > 0 and max(left_gaps) < start:
             new_gaps.append([max(left_gaps), start, self.__total_nodes])
-        end = self.__reserved_jobs[new_job] +\
-              new_job.get_current_total_request_time()
+        end = self.__reserved_jobs[new_job] \
+            + new_job.get_current_total_request_time()
         right_gaps = [self.__reserved_jobs[job] for job in self.__reserved_jobs
                       if self.__reserved_jobs[job] >= end]
         if len(right_gaps) and min(right_gaps) > end:
@@ -466,7 +466,7 @@ class ScheduleGaps(object):
             return self.gaps_list
         job_list[job] = self.__reserved_jobs[job]
         return self.update(job_list, 2)
-    
+
     def get_gaps(self, start_time, length, nodes):
         ''' Return all the gaps that can fit a job using a given number of
         nodes, requiring a length walltime and that has to start the earliest

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -558,7 +558,6 @@ class Runtime(object):
 
         # at the end of the simulation return default values for all the jobs
         for job in self.__finished_jobs:
-            self.__log_finalize(job)
             job.restore_default_values()
 
         # end the progress bar

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -637,6 +637,8 @@ class Runtime(object):
         # create a job end event for the started job
         # for timestamp current_time + execution_time
         execution = job.walltime + job.get_checkpoint_read_time()
+        # execution time is the walltime + time to read the last checkpoint
+        # in case of successful run or the total request time
         if job.walltime > job.request_walltime:
             execution = job.get_current_total_request_time()
         self.__events.push(

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -27,6 +27,7 @@ class JobChangeType(IntEnum):
     SubmissionChange = 0
     RequestChange = 1
     RequestSequenceOverwrite = 2
+    CheckpointSizeChange = 3
 
 
 class EventType(IntEnum):

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -25,10 +25,7 @@ class JobChangeType(IntEnum):
     that can be applied to an Application properties '''
 
     SubmissionChange = 0
-    RequestChange = 1
-    RequestSequenceOverwrite = 2
-    CheckpointSizeChange = 3
-    WalltimeChange = 4
+    WalltimeChange = 1
 
 
 class EventType(IntEnum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-scipy

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -11,7 +11,7 @@ python -m unittest test_unittest.TestSystem $1
 
 echo "---------------------------------"
 echo "Test Checkpointing"
-python -m unittest test_unittest.TestCheckpointing $1
+python -m unittest test_unittest.TestCheckpointing $1 > /dev/null
 
 echo "---------------------------------"
 echo "Test Applications"

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -10,6 +10,10 @@ echo "Test System"
 python -m unittest test_unittest.TestSystem $1
 
 echo "---------------------------------"
+echo "Test Checkpointing"
+python -m unittest test_unittest.TestCheckpointing $1
+
+echo "---------------------------------"
 echo "Test Applications"
 python -m unittest test_unittest.TestApplication $1
 

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -27,9 +27,9 @@ python -m unittest test_unittest.TestBatchScheduler $1
 
 echo "---------------------------------"
 echo "Test Runtime"
-python -m unittest test_unittest.TestRuntime $1
+python -m unittest test_unittest.TestRuntime $1 > /dev/null
 
 echo "---------------------------------"
 echo "Test Simulator"
-python -m unittest test_unittest.TestSimulator $1
+python -m unittest test_unittest.TestSimulator $1 > /dev/null
 

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -180,6 +180,12 @@ class TestApplication(unittest.TestCase):
         job_list.overwrite_request_sequence([190, 200])
         self.assertEqual(job_list.get_request_time(1), 190)
 
+    def test_checkpoint(self):
+        job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
+                                       resubmit_factor=1.5)
+        set_checkpointing([20, 10, 50],
+                          resubmission_checkpointing=True)
+
     def test_invalid_job(self):
         with self.assertRaises(AssertionError):
             ScheduleFlow.Application(0, 0, 10, [11])

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -59,10 +59,10 @@ class TestWaitingQueue(unittest.TestCase):
         wq.add(ScheduleFlow.Application(2, 0, 800, [500]))
         self.assertEqual(wq.total_priority_jobs(), 1)
         self.assertEqual(wq.total_secondary_jobs(), 2)
-    
+
     def test_invalid_wq(self):
         with self.assertRaises(AssertionError):
-            wq = WaitingQueue(total_queues=0)
+            WaitingQueue(total_queues=0)
 
     def test_remove_fail(self):
         wq = WaitingQueue()
@@ -72,37 +72,37 @@ class TestWaitingQueue(unittest.TestCase):
 
     def test_remove(self):
         wq = WaitingQueue()
-        job_list = [] 
+        job_list = []
         job_list.append(ScheduleFlow.Application(10, 0, 1800, [4500]))
         job_list.append(ScheduleFlow.Application(10, 0, 1800, [1800]))
         job_list.append(ScheduleFlow.Application(2, 0, 800, [500]))
         for job in job_list:
             wq.add(job)
         wq.remove(job_list[0])
-        self.assertEqual(wq.total_priority_jobs(),0)
+        self.assertEqual(wq.total_priority_jobs(), 0)
         with self.assertRaises(AssertionError):
             wq.remove(job_list[0])
         wq.remove(job_list[1])
-        self.assertEqual(wq.total_secondary_jobs(),1)
+        self.assertEqual(wq.total_secondary_jobs(), 1)
 
     def test_update_empty(self):
         wq = WaitingQueue()
         wq.add(ScheduleFlow.Application(10, 0, 1800, [1800]))
         wq.add(ScheduleFlow.Application(2, 0, 800, [500]))
         wq.update_priority(0)
-        self.assertEqual(len(wq.get_priority_jobs()),0)
-        wq.fill_priority_queue() 
-        self.assertEqual(len(wq.get_priority_jobs()),1)
+        self.assertEqual(len(wq.get_priority_jobs()), 0)
+        wq.fill_priority_queue()
+        self.assertEqual(len(wq.get_priority_jobs()), 1)
 
     def test_update_priority(self):
         wq = WaitingQueue()
         wq.add(ScheduleFlow.Application(10, 0, 1800, [4500]))
         wq.add(ScheduleFlow.Application(10, 100, 1800, [1800]))
         wq.add(ScheduleFlow.Application(2, 0, 800, [500]))
-        wq.update_priority(0) 
-        self.assertEqual(len(wq.get_priority_jobs()),1)
-        wq.update_priority(1900) 
-        self.assertEqual(len(wq.get_priority_jobs()),2)
+        wq.update_priority(0)
+        self.assertEqual(len(wq.get_priority_jobs()), 1)
+        wq.update_priority(1900)
+        self.assertEqual(len(wq.get_priority_jobs()), 2)
 
     def test_one_queue(self):
         wq = WaitingQueue(total_queues=1)
@@ -201,7 +201,6 @@ class TestApplication(unittest.TestCase):
         with self.assertRaises(AssertionError):
             job.update_submission(9)
 
-
     def test_request_list_factor(self):
         ap = ScheduleFlow.Application(7, 5, 100, [70, 80, 90],
                                       resubmit_factor=2)
@@ -255,14 +254,14 @@ class TestCheckpointing(unittest.TestCase):
                                        resubmit_factor=1.5)
         self.assertTrue(job.current_checkpoint <= 0)
         self.assertEqual(len(job.checkpoint_sequence), 0)
-        
+
     def test_set_checkpoint(self):
         job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
                                        resubmit_factor=1.5)
         job.set_checkpointing([25, 20, 10, 50])
         self.assertEqual(job.current_checkpoint, 25)
         self.assertEqual(len(job.checkpoint_sequence), 4)
-    
+
     def test_get_checkpoint(self):
         job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
                                        resubmit_factor=1.5)
@@ -301,7 +300,7 @@ class TestCheckpointing(unittest.TestCase):
                 job.set_checkpointing([10])
                 job.assign_system(system)
                 reservation[job] = i * 60
-                if i==2:
+                if i == 2:
                     break
         sch.gaps_in_schedule.add(reservation)
         job = ScheduleFlow.Application(1, 0, 50, [50])
@@ -320,7 +319,7 @@ class TestCheckpointing(unittest.TestCase):
                 job.set_checkpointing([10])
                 job.assign_system(system)
                 reservation[job] = i * 60
-                if i==2:
+                if i == 2:
                     break
         sch.gaps_in_schedule.add(reservation)
         job = ScheduleFlow.Application(1, 0, 50, [50])
@@ -352,7 +351,7 @@ class TestCheckpointing(unittest.TestCase):
         ret = sim.run()
         self.assertEqual(ret['job failures'], 2)
         self.assertEqual(ret['job response time'], 230)
-    
+
     def test_simulation_correctness(self):
         sim = ScheduleFlow.Simulator(check_correctness=True)
         job_list = [
@@ -392,9 +391,10 @@ class TestScheduleGaps(unittest.TestCase):
         gaps = sch.gaps_in_schedule.update(reservations, -1)
         self.assertTrue(len(gaps) == 2)
         self.assertEqual(set([i[2] for i in gaps]), set([2, 5]))
-        gaps = sch.gaps_in_schedule.update({ScheduleFlow.Application(2, 0, 1, [1]): 4}, -1)
+        gaps = sch.gaps_in_schedule.update(
+                {ScheduleFlow.Application(2, 0, 1, [1]): 4}, -1)
         self.assertEqual(max([i[1]-i[0] for i in gaps]), 4)
-    
+
     def test_left_void_in_middle(self):
         sch = ScheduleFlow.BatchScheduler(ScheduleFlow.System(10), 10)
         reservation = {}
@@ -436,9 +436,9 @@ class TestScheduleGaps(unittest.TestCase):
         reservations[ScheduleFlow.Application(10, 0, 3, [5])] = 10
         gaps = sch.gaps_in_schedule.update(reservations, -1)
 
-        gaps = sch.gaps_in_schedule.update({job : 5}, 1)
+        gaps = sch.gaps_in_schedule.update({job: 5}, 1)
         self.assertTrue(len(gaps) == 3)
-        self.assertEqual([i for i in gaps if i[0]==7][0], [7, 10, 1])
+        self.assertEqual([i for i in gaps if i[0] == 7][0], [7, 10, 1])
 
     def test_reservation_batch(self):
         sch = ScheduleFlow.BatchScheduler(ScheduleFlow.System(10))
@@ -659,7 +659,7 @@ class TestBatchScheduler(unittest.TestCase):
             procs = np.random.randint(6, 10)
             sch.submit_job(ScheduleFlow.Application(
                 procs, 0, exect, [exect]))
-        ap_list = sch.trigger_schedule(0)  
+        ap_list = sch.trigger_schedule(0)
         ap_list.sort()
         exec_order = [
             job[1].nodes *
@@ -803,7 +803,7 @@ class TestRuntime(unittest.TestCase):
             workload = runtime.get_stats()
             exec_order = sorted(
                     [(job.walltime, workload[job][0][0]) for job in workload],
-                    key=lambda job:job[1])
+                    key=lambda job: job[1])
             self.assertListEqual([i[0] for i in exec_order], [7000, 300, 1000])
             sch = SchedulerType(ScheduleFlow.System(10),
                                 total_queues=1)
@@ -816,7 +816,7 @@ class TestRuntime(unittest.TestCase):
             workload = runtime.get_stats()
             exec_order = sorted(
                     [(job.walltime, workload[job][0][0]) for job in workload],
-                    key=lambda job:job[1])
+                    key=lambda job: job[1])
             self.assertListEqual([i[0] for i in exec_order], [7000, 1000, 300])
 
     def test_batch_wq_backfill(self):
@@ -851,7 +851,7 @@ class TestRuntime(unittest.TestCase):
             19000)
 
     def test_space_out_jobs(self):
-        for num_queues in range(1,3):
+        for num_queues in range(1, 3):
             for SchedulerType in ScheduleFlow.Scheduler.__subclasses__():
                 sch = SchedulerType(ScheduleFlow.System(10),
                                     total_queues=num_queues)
@@ -862,9 +862,9 @@ class TestRuntime(unittest.TestCase):
                 runtime(sch)
                 workload = runtime.get_stats()
                 self.assertEqual(
-                    max([workload[i][len(workload[i])-1][1] for i in workload]),
+                    max([workload[i][len(workload[i])-1][1]
+                         for i in workload]),
                     17000)
-
 
     def test_same_start(self):
         for SchedulerType in ScheduleFlow.Scheduler.__subclasses__():
@@ -1160,7 +1160,7 @@ class TestSimulator(unittest.TestCase):
     def test_run_scenario(self):
         sim = ScheduleFlow.Simulator()
         with self.assertRaises(AssertionError):
-            ret = sim.run()
+            sim.run()
         job_list = [ScheduleFlow.Application(6, 0, 500, [1000]),
                     ScheduleFlow.Application(6, 0, 500, [1000])]
         sim.create_scenario(

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -173,12 +173,8 @@ class TestApplication(unittest.TestCase):
     def test_sequence_overwrite(self):
         job_list = ScheduleFlow.Application(10, 0, 200, [100],
                                             resubmit_factor=1.5)
-        with self.assertRaises(AssertionError):
-            job_list.overwrite_request_sequence([100, 150])
-        with self.assertRaises(AssertionError):
-            job_list.overwrite_request_sequence([200, 150])
         job_list.overwrite_request_sequence([190, 200])
-        self.assertEqual(job_list.get_request_time(1), 190)
+        self.assertEqual(job_list.get_request_time(0), 190)
 
     def test_invalid_job(self):
         with self.assertRaises(AssertionError):
@@ -190,9 +186,10 @@ class TestApplication(unittest.TestCase):
         with self.assertRaises(AssertionError):
             ScheduleFlow.Application(10, -2, 10, [11])
         with self.assertRaises(AssertionError):
-            ScheduleFlow.Application(10, 0, 10, [7, 12, 10])
-        with self.assertRaises(AssertionError):
             ScheduleFlow.Application(10, 0, 10, [])
+        ap = ScheduleFlow.Application(10, 0, 10, [5, 3])
+        with self.assertRaises(AssertionError):
+            ap.update_submission(5)
 
     def test_invalid_factor(self):
         with self.assertRaises(AssertionError):
@@ -211,7 +208,7 @@ class TestApplication(unittest.TestCase):
 
     def __check_initial_data(self, job):
         self.assertEqual(job.submission_time, 0)
-        self.assertEqual(job.request_sequence, [200, 300])
+        self.assertEqual(job.request_sequence, [100, 200, 300])
         self.assertEqual(job.request_walltime, 100)
         self.assertEqual(job.current_checkpoint, 25)
         self.assertEqual(job.checkpoint_sequence, [25, 10, 20, 15])
@@ -241,7 +238,7 @@ class TestApplication(unittest.TestCase):
         self.assertTrue(job.current_checkpoint <= 0)
         job.restore_default_values()
         self.assertTrue(job.current_checkpoint <= 0)
-        self.assertEqual(job.request_sequence, [200, 300])
+        self.assertEqual(job.request_sequence, [100, 200, 300])
         self.assertEqual(job.request_walltime, 100)
 
 
@@ -681,7 +678,7 @@ class TestRuntime(unittest.TestCase):
             for job in workload:
                 self.assertEqual(job.submission_time, 0)
                 self.assertEqual(job.request_walltime, 80)
-                self.assertEqual(job.request_sequence[0], 100)
+                self.assertEqual(job.request_sequence[1], 100)
 
     def test_empty_workload(self):
         for SchedulerType in ScheduleFlow.Scheduler.__subclasses__():

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -180,12 +180,6 @@ class TestApplication(unittest.TestCase):
         job_list.overwrite_request_sequence([190, 200])
         self.assertEqual(job_list.get_request_time(1), 190)
 
-    def test_checkpoint(self):
-        job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
-                                       resubmit_factor=1.5)
-        job.set_checkpointing([25, 20, 10, 50],
-                              resubmission_checkpointing=True)
-
     def test_invalid_job(self):
         with self.assertRaises(AssertionError):
             ScheduleFlow.Application(0, 0, 10, [11])

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -209,6 +209,28 @@ class TestApplication(unittest.TestCase):
         ap.update_submission(0)
         self.assertEqual(ap.request_walltime, 180)
 
+    def __check_initial_data(self, job):
+        self.assertEqual(job.submission_time, 0)
+        self.assertEqual(job.request_sequence, [200, 300])
+        self.assertEqual(job.request_walltime, 100)
+        self.assertEqual(job.current_checkpoint, 25)
+        self.assertEqual(job.checkpoint_sequence, [10, 20, 15])
+
+    def test_restore_data(self):
+        job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
+                                       resubmit_factor=1.5)
+        job.set_checkpointing([25, 10, 20, 15])
+        job.update_submission(200)
+        self.assertEqual(job.current_checkpoint, 10)
+        job.update_submission(300)
+        job.update_submission(500)
+        self.assertEqual(job.current_checkpoint, 15)
+        job.restore_default_values()
+        self.__check_initial_data(job)
+        job.update_submission(200)
+        job.restore_default_values()
+        self.__check_initial_data(job)
+
 
 # test the checkpointing capabilities of the scheduler
 class TestCheckpointing(unittest.TestCase):
@@ -245,23 +267,6 @@ class TestCheckpointing(unittest.TestCase):
         self.assertTrue(job.current_checkpoint <= 0)
         self.assertEqual(job.request_sequence, [200, 300])
         self.assertEqual(job.request_walltime, 100)
-
-    def test_restore_checkpoint(self):
-        job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
-                                       resubmit_factor=1.5)
-        job.set_checkpointing([25, 10, 20, 15])
-        job.update_submission(200)
-        self.assertEqual(job.current_checkpoint, 10)
-        job.update_submission(300)
-        job.update_submission(500)
-        self.assertEqual(job.current_checkpoint, 15)
-        job.restore_default_values()
-        self.assertEqual(job.current_checkpoint, 25)
-        self.assertEqual(job.checkpoint_sequence, [10, 20, 15])
-        job.update_submission(200)
-        job.restore_default_values()
-        self.assertEqual(job.current_checkpoint, 25)
-        self.assertEqual(job.checkpoint_sequence, [10, 20, 15])
 
 
 # test the ScheduleGaps class

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -442,55 +442,66 @@ class TestOnlineScheduler(unittest.TestCase):
         self.assertEqual(len(ap_list), num_jobs)
 
     def test_nofit_in_schedule(self):
-        sch = ScheduleFlow.OnlineScheduler(ScheduleFlow.System(10))
+        system = ScheduleFlow.System(10)
+        sch = ScheduleFlow.OnlineScheduler(system)
         reservation = {}
         for i in range(5):
             reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
             reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
-        ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(1, 0, 50, [50]), reservation)
+        sch.gaps_in_schedule.add(reservation)
+        job = ScheduleFlow.Application(1, 0, 50, [50])
+        ret = sch.fit_job_in_schedule(job)
         self.assertEqual(ret, -1)
 
     def test_fit_middle(self):
-        sch = ScheduleFlow.OnlineScheduler(ScheduleFlow.System(10))
+        system = ScheduleFlow.System(10)
+        sch = ScheduleFlow.OnlineScheduler(system)
         reservation = {}
         for i in list(range(5)) + list(range(6, 10)):
-            reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
-            reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
+            job = ScheduleFlow.Application(5, 0, 50, [50])
+            reservation[job] = i * 50
+            job = ScheduleFlow.Application(5, 0, 50, [50])
+            reservation[job] = i * 50
         # add random number of one node jobs ( < 8 total jobs )
         # with execution times <= 50
         num_jobs = np.random.randint(1, 8)
         for i in range(num_jobs):
-            reservation[ScheduleFlow.Application(
-                1, 0, 50 - i, [50 - i])] = 250
+            job = ScheduleFlow.Application(
+                1, 0, 50 - i, [50 - i])
+            reservation[job] = 250
         sch.gaps_in_schedule.add(reservation)
         # try to fit an application of execution time = 40 and 2 nodes whose
         # submission time is 5 over when the gap is available
-        ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(2, 255, 40, [40]), reservation)
+        job = ScheduleFlow.Application(2, 255, 40, [40])
+        ret = sch.fit_job_in_schedule(job)
         self.assertEqual(ret, 255)
 
     def test_fit_end(self):
-        sch = ScheduleFlow.OnlineScheduler(ScheduleFlow.System(10))
+        system = ScheduleFlow.System(10)
+        sch = ScheduleFlow.OnlineScheduler(system)
         reservation = {}
         for i in range(5):
-            reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
-            reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
-        reservation[ScheduleFlow.Application(4, 0, 10, [10])] = 250
+            job = ScheduleFlow.Application(5, 0, 50, [50])
+            reservation[job] = i * 50
+            job = ScheduleFlow.Application(5, 0, 50, [50])
+            reservation[job] = i * 50
+        job = ScheduleFlow.Application(4, 0, 10, [10])
+        reservation[job] = 250
         sch.gaps_in_schedule.add(reservation)
         # fit a job that is larger than the gap at the end
         ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(6, 255, 50, [50]), reservation)
+            ScheduleFlow.Application(6, 255, 50, [50]))
         self.assertEqual(ret, 255)
         ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(6, 265, 50, [50]), reservation)
+            ScheduleFlow.Application(6, 265, 50, [50]))
         self.assertEqual(ret, -1)
 
 
 # test the batch scheduler class
 class TestBatchScheduler(unittest.TestCase):
     def test_nofit_end(self):
-        sch = ScheduleFlow.BatchScheduler(ScheduleFlow.System(10), 15)
+        system = ScheduleFlow.System(10)
+        sch = ScheduleFlow.BatchScheduler(system, 15)
         reservation = {}
         for i in range(5):
             reservation[ScheduleFlow.Application(5, 0, 50, [50])] = i * 50
@@ -499,7 +510,7 @@ class TestBatchScheduler(unittest.TestCase):
         sch.gaps_in_schedule.add(reservation)
         # fit a job that is larger than the gap at the end
         ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(6, 0, 50, [50]), reservation)
+            ScheduleFlow.Application(6, 0, 50, [50]))
         self.assertEqual(ret, -1)
 
     def test_fit_end(self):
@@ -513,7 +524,7 @@ class TestBatchScheduler(unittest.TestCase):
         # 5 over when the gap is available)
         sch.gaps_in_schedule.add(reservation)
         ret = sch.fit_job_in_schedule(
-            ScheduleFlow.Application(6, 255, 5, [5]), reservation)
+            ScheduleFlow.Application(6, 255, 5, [5]))
         self.assertEqual(ret, 255)
 
     def test_one_node_jobs(self):

--- a/test_unittest.py
+++ b/test_unittest.py
@@ -183,8 +183,8 @@ class TestApplication(unittest.TestCase):
     def test_checkpoint(self):
         job = ScheduleFlow.Application(10, 0, 200, [100, 200, 300],
                                        resubmit_factor=1.5)
-        set_checkpointing([20, 10, 50],
-                          resubmission_checkpointing=True)
+        job.set_checkpointing([25, 20, 10, 50],
+                              resubmission_checkpointing=True)
 
     def test_invalid_job(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Closes #78 

sequence of requests [r1, r2, r3] - r_last * 1.5
sequence of checkpoints [c1, c2, c3] - c3 until the end (or no checkpoint)

- initialization: `request_time + current_checkpoint.time_to_write`

- when a job finishes: 
	- in case of resubmission:
```
request_time = current_checkpoint.time_to_read + new_request + new_checkpoint.time_to_write

if current_checkpoint != 0:
	walltime = walltime - request_time
```