### PR TITLE
Bug fixes

### DIFF
--- a/ScheduleFlow.py
+++ b/ScheduleFlow.py
@@ -145,7 +145,7 @@ class Simulator():
         ''' Method for sending additional applications to the simulation '''
 
         for new_job in job_list:
-            add_application(new_job)
+            self.add_application(new_job)
         return len(self.job_list)
 
     def __sanity_check_job_execution(self, execution_list, job):
@@ -283,7 +283,7 @@ class Simulator():
         self.__viz_handler.set_execution_log(execution_log)
         self.horizontal_ax = self.__viz_handler.generate_scenario_gif(
             scenario_name)
-        self.logger.info(r"GIF generated in %s/draw/%s" % (
+        self.logger.info(r"GIF generated in %s/draw/%s.gif" % (
             os.environ["ScheduleFlow_PATH"], scenario_name))
 
     def generate_statistics(self, execution_log, metrics=["all"]):
@@ -678,7 +678,7 @@ class Scheduler(object):
     ''' Class that implements the scheduler functionality (i.e. choosing
         what are the jobs scheduled to run and backfillinf jobs) '''
 
-    def __init__(self, system, priorityLevels, logger=None,
+    def __init__(self, system, priorityLevels=1, logger=None,
                  priority_policy=PriorityPolicy.FCFS,
                  backfill_policy=BackfillPolicy.Easy):
         self.system = system

--- a/_intScheduleFlow.py
+++ b/_intScheduleFlow.py
@@ -427,8 +427,8 @@ class ScheduleGaps(object):
 
         # reserved_jobs[job] = time
         for job in reserved_jobs:
-            assert(job not in self.__reserved_jobs, "ERR Cannot add"
-                   "a job that is already part of a schedule")
+            assert job not in self.__reserved_jobs, "ERR Cannot add "\
+                   "a job that is already part of a schedule"
             self.__update_reserved_list(job, reserved_jobs[job], ops)
             start = reserved_jobs[job]
             request_walltime = job.get_current_total_request_time()
@@ -686,7 +686,8 @@ class Runtime(object):
                 # if successful update the progress bar
                 if self.__logger == None:
                     self.update_progressbar()
-                self.__log_end(job)
+            # mark the end of the submission
+            self.__log_end(job)
 
         # handle backfilling jobs and new jobs ready to be executed
         ret = self.scheduler.stop_job(self.__current_time, job_list)
@@ -747,7 +748,7 @@ class TexGenerator():
                                  "/draw/tex_header").readlines()])
             # add legend on the vertical axes, needs to be out of the header
             # since the total number of procs is not known in the tex file
-            outf.write("\draw[-, very thick] (-1, 151) -- (1, 151) node [pos=0, left] {$\scriptstyle{%d}$};" %(self.__labely))
+            outf.write("\\draw[-, very thick] (-1, 151) -- (1, 151) node [pos=0, left] {$\\scriptstyle{%d}$};" %(self.__labely))
             self.__print_execution_list(i + 1, outf)
             if i < self.__total_runs:
                 # write last job start and end times

--- a/examples/generate_gif_example.py
+++ b/examples/generate_gif_example.py
@@ -8,19 +8,13 @@ def run_scenario(num_processing_units, job_list):
     simulator = ScheduleFlow.Simulator(check_correctness=True,
                                        generate_gif=True,
                                        output_file_handler=sys.stdout)
-    sch = ScheduleFlow.BatchScheduler(
+    sch = ScheduleFlow.Scheduler(
         ScheduleFlow.System(num_processing_units))
     simulator.create_scenario(sch, job_list=job_list,
                               scenario_name="test_batch")
-    simulator.run()
+    execution = simulator.run(metrics="execution_log")
+    print(execution)
     
-    sch = ScheduleFlow.BatchScheduler(
-        ScheduleFlow.System(num_processing_units),
-        total_queues=2)
-    simulator.create_scenario(sch, job_list=job_list,
-                              scenario_name="test_batch")
-    simulator.run()
-
 if __name__ == '__main__':
     os.environ["ScheduleFlow_PATH"] = ".."
     num_processing_units = 10
@@ -37,9 +31,9 @@ if __name__ == '__main__':
             processing_units,
             submission_time,
             execution_time,
-            [request_time]))
+            [request_time], name="J"+str(i)))
     # add a job that request less time than required for its first run
     job_list.add(ScheduleFlow.Application(np.random.randint(9, 11), 0,
-                                          5000, [4000, 5500]))
+                                          5000, [4000, 5500], name="J10"))
 
     run_scenario(num_processing_units, job_list)


### PR DESCRIPTION
Error when a job fails firsts the execution log showed -1 as the finishing time for the failed job.


Fix:
```diff
                # if successful update the progress bar
                if self.__logger == None:
                    self.update_progressbar()
-                self.__log_end(job)
+            # mark the end of the submission
+            self.__log_end(job)

        # handle backfilling jobs and new jobs ready to be executed
        ret = self.scheduler.stop_job(self.__current_time, job_list)
```

+ Other small fixes.